### PR TITLE
Add a top nav link to the github repo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,7 @@ readme_index:
   enabled:          true
   remove_originals: false
   with_frontmatter: true
+aux_links:
+  "DLS Handbook on GitHub":
+    - "//github.com/pulibrary/dls-handbook"
+aux_links_new_tab: true


### PR DESCRIPTION
Followed documentation at https://pmarsceill.github.io/just-the-docs/docs/configuration/#aux-links

I also added the website in the "about" area of the repo, which puts a link to the rendered site in the right sidebar of the github repo page. (see screenshot)

![Screen Shot 2021-10-28 at 10 14 19 AM](https://user-images.githubusercontent.com/845363/139274551-a224e0b2-c0f5-4416-b0e9-e9f8ad6e501b.png)

closes #24 