### PR TITLE
Adds page on inclusive language

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ nav_order: 1
 1. [Student Software Developers](student_software_developers.md)
 1. [Vacation](/vacation.md)
 1. [Tooling](/tooling.md)
+1. [Inclusive Language](/inclusive_language.md)

--- a/inclusive_language.md
+++ b/inclusive_language.md
@@ -4,14 +4,14 @@ Digital Library Services strives to use inclusive language in all aspects of our
 
 Inclusive language avoids biases, slang, or expressions that discriminate against groups of people based on race, gender, or socioeconomic status. DLS actively seeks collaboration in identifying and addressing non-inclusive and harmful language that may appear in our work and artifacts.
 
-To report instances of non-inclusive language to DLS, you may ... ?
+If you encounter non-inclusive language in the course of your work, open an issue, submit a pull request, mention it on slack, or add it to a standup agenda.
 
 The following table includes examples of alternate labels DLS has adopted for some common non-inclusive or harmful terms:
 
 | Depricated             | Inclusive         |
 | ---------------------- | -------------- |
-| Whitelist              | 	Allowlist |
-| Blacklist              | (or ignore_list, excluded_x, skipped_x) as appropriate for the context   |
+| Whitelist              | Allowlist |
+| Blacklist              | Denylist (or ignore_list, excluded_x, skipped_x) as appropriate for the context   |
 | Master/slave           | primary/replica/         |
 | Master branch          | main |
 | Grandfathered          | Legacy status |

--- a/inclusive_language.md
+++ b/inclusive_language.md
@@ -1,0 +1,25 @@
+# DLS Intent on Inclusive Language
+
+Digital Library Services strives to use inclusive language in all aspects of our work. This includes, but is not limited to, language used in communications, code, documentation, workflows, and 3rd party software selection.
+
+Inclusive language avoids biases, slang, or expressions that discriminate against groups of people based on race, gender, or socioeconomic status. DLS actively seeks collaboration in identifying and addressing non-inclusive and harmful language that may appear in our work and artifacts.
+
+To report instances of non-inclusive language to DLS, you may ... ?
+
+The following table includes examples of alternate labels DLS has adopted for some common non-inclusive or harmful terms:
+
+| Depricated             | Inclusive         |
+| ---------------------- | -------------- |
+| Whitelist              | 	Allowlist |
+| Blacklist              | (or ignore_list, excluded_x, skipped_x) as appropriate for the context   |
+| Master/slave           | primary/replica/         |
+| Master branch          | main |
+| Grandfathered          | Legacy status |
+| Gendered pronouns (e. g. guys) | 	Folks, people, you all |
+| Gendered pronouns (e. g. he/him/his) | 	They, them, their |
+| Man hours              | 	Person hours, engineer hours |
+| Developer sanity       | 	Developer experience (DX), ease of use, “notes to future self” |
+| Sanity check           | 	Quick check, confidence check, coherence check, double check |
+| Dummy value            | 	Placeholder value, sample value |
+| Freshman               | 		First-year |
+| User testing           | 	Usability testing |


### PR DESCRIPTION
One remaining question is how should we ask our DLS handbook audience to report instances of non-inclusive language? Is this done by creating tickets? Or notifying Trey? Other protocol?

closes #39 