### PR TITLE
Update page titles to improve sidebar TOC sorting, reorder some readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ nav_order: 1
 
 ## Documentation for general use
 
-1. [Applications](/applications.md)
+1. [Applications](/applications.md) - Information about applications in the DLS portfolio
+1. [Issues](/issues.md) - Writing and specifying tickets
+1. [Product Owners](/product_owners.md)
 1. [Technical Liaisons](/technical_liaisons.md)
 1. [Work Cycles](/work_cycles.md)
-1. [Product Owners](/product_owners.md)
-1. [Issues](/issues.md)
-1. [Administrative Resources](/admin_resources.md)
 
 ## Documentation most useful to members of our team
 
-1. [Runner](/runner.md) - The nature and duties of the rotating "runner" role
+1. [Administrative Resources](/admin_resources.md)
 1. [Development Practice](/development_practice.md)
+1. [Development Tooling](/tooling.md)
 1. [Improving User Experience](/ux_research.md)
+1. [Inclusive Language](/inclusive_language.md)
+1. [Runner](/runner.md) - The nature and duties of the rotating "runner" role
 1. [Student Software Developers](student_software_developers.md)
 1. [Vacation](/vacation.md)
-1. [Tooling](/tooling.md)
-1. [Inclusive Language](/inclusive_language.md)

--- a/applications.md
+++ b/applications.md
@@ -1,4 +1,4 @@
-# DLS Applications
+# Applications
 
 [Architecture diagram](https://docs.google.com/drawings/d/1qqHoceL4nahv8wmhK_QltL8f1StdBJ5GYFpIa6JQ3PA/edit)
 

--- a/inclusive_language.md
+++ b/inclusive_language.md
@@ -1,4 +1,4 @@
-# DLS Intent on Inclusive Language
+# Inclusive Language
 
 Digital Library Services strives to use inclusive language in all aspects of our work. This includes, but is not limited to, language used in communications, code, documentation, workflows, and 3rd party software selection.
 

--- a/work_cycles.md
+++ b/work_cycles.md
@@ -1,4 +1,4 @@
-# DLS Work Cycles
+# Work Cycles
 
 ## Development Rhythm
 


### PR DESCRIPTION
including make the readme links alphabetical per section.

hopefully this makes the sidebar toc more consistent with the readme so it's clear they're two representations of the same content.