### PR TITLE
Add "team integration" strategies to student developers page

### DIFF
--- a/index.md
+++ b/index.md
@@ -39,6 +39,7 @@ DLS will prioritize development work and organization processes in such a way as
 1. [Development Tooling](/tooling.md)
 1. [Improving User Experience](/ux_research.md)
 1. [Inclusive Language](/inclusive_language.md)
+1. [Onboarding](/onboarding.md) to the DLS team
 1. [Runner](/runner.md) - The nature and duties of the rotating "runner" role
 1. [Student Software Developers](student_software_developers.md)
 1. [Vacation](/vacation.md)

--- a/onboarding.md
+++ b/onboarding.md
@@ -2,9 +2,10 @@
 
 DLS strives to be welcoming and inclusive in our onboarding process for new team members. The initial tasks for any new team member will include:
 
-- Becoming familiar with our team and department handbooks and Library goals
-- Setting up hardware, including a development environment and password management
+- Becoming familiar with this team handbook, [the departmental handbook](https://github.com/pulibrary/pul-it-handbook/), and [Library mission](https://library.princeton.edu/about)
+- Setting up hardware, including a development environment and password manager
 - Creating accounts across a variety of services
-- Work through training curriculum, if relevant, and pair with DLS colleagues
+- Working through a training curriculum, if relevant
+- Pairing with DLS colleagues
 
 New team members will be supported in these tasks by a DLS buddy assigned on a weekly basis. The buddy's first priority is to ensure the new team member is not blocked on any of their onboarding or other work, to answer the new team member's questions, and to pair with the new team member as needed.

--- a/onboarding.md
+++ b/onboarding.md
@@ -1,0 +1,10 @@
+# Onboarding
+
+DLS strives to be welcoming and inclusive in our onboarding process for new team members. The initial tasks for any new team member will include:
+
+- Becoming familiar with our team and department handbooks and Library goals
+- Setting up hardware, including a development environment and password management
+- Creating accounts across a variety of services
+- Work through training curriculum, if relevant, and pair with DLS colleagues
+
+New team members will be supported in these tasks by a DLS buddy assigned on a weekly basis. The buddy's first priority is to ensure the new team member is not blocked on any of their onboarding or other work, to answer the new team member's questions, and to pair with the new team member as needed.

--- a/student_software_developers.md
+++ b/student_software_developers.md
@@ -1,17 +1,43 @@
-# Student Software Developers
+# Student Software and UX Developers
 
 ## Program
 
 Our goal in this program is to fully integrate undergraduate developers into our team. These developers will be paired with members of DLS to initially build skills and then work issues to advance our software.
 
-## Student Employee Policy
-There is a library-wide [Student Employee Policy](https://pulstaff.princeton.edu/working-pul/library-student-employee-policy/) on the Connecting staff Intranet site.
+## Team Integration
 
-## Timesheets
+Student Developers will operate as a member of the DLS team, with the exception
+that their mentor acts as their direct supervisor. This means they will have a
+buddy from DLS as part of their onboarding, and will pair with various members
+of the team and have a weekly check-in with their mentor.
 
-Student Software Developers are paid biweekly. Timesheet and pay schedules are available on the [Payroll Cycles website](https://finance.princeton.edu/payroll-labor-accounting/payroll/payroll-basics/monthly-and-biweekly-payroll-cycles)
+During the summer students will attend all DLS team meetings and participate on
+the team slack channel. These communication outlets will allow for us to arrange
+pairing sessions as needed.
 
-## Schedules
+During the school year students should continue to use the team slack channel to
+collaborate with DLS team members. If a student's work schedule allows them to
+attend the team stand-up they should do so. If not they should post a stand-up
+style check in to the team slack channel, and ask for a pair if needed. Students
+and mentors should continue to have a weekly 1:1 meeting.
+
+### Absence from Work
+
+If a student will miss their shift for any reason, they should post a message in the team slack channel saying that they won't be in. This ensures the team knows not to expect them in meetings, etc, even if their supervisor is also out. The student should follow up individually with their supervisor as to whether they will be using sick time or unpaid time.
+
+## Policies
+There is a library-wide [Student Employee Policy](https://pulstaff.princeton.edu/working-pul/library-student-employee-policy/), which covers accrued sick time, on the Connecting staff Intranet site. Note that the policies regarding shift replacements for absence are not relevant to these positions.
+
+The pul-it-handbook has a page of [Policies specific to the Student Developers program](https://github.com/pulibrary/pul-it-handbook/blob/main/student-software-developers/requirements-and-policies.md), including work schedule expectations.
+
+## Hiring and Onboarding
+Hiring and mentorship documentation is maintained in the [Student Software Developers Administration Handbook](https://github.com/pulibrary/pul-it-handbook/blob/main/student-software-developers/administration-handbook.md) in the pul-it-handbook repository.
+
+Day 1 onboarding documentation is maintained in the [Student Software Developers Student Handbook](https://github.com/pulibrary/pul-it-handbook/blob/main/student-software-developers/student-handbook.md)
+
+Otherwise, onboarding for students will follow the same process as [onboarding](/onboarding.md) for other team members.
+
+## Schedule Calendar
 
 Student Software Developer schedules are tracked in a shared calendar called
 "DLS Student Developers". DLS staff should request access to view and manage
@@ -19,20 +45,9 @@ this calendar from the manager of DLS. The account and password for this
 exchange account is in LastPass under `Shared-ITIMS-Passwords/DLS/DLSStudentDevs
 email`, but 2FA is set up for use by the current manager of DLS.
 
-During the summer Student Software Developers work full-time hours. During the
-school year they work part-time when classes are in session. Students can work
-at other times, e.g. reading week, if desired.
+## Timesheets
 
-## Time off
-
-Student employees accrue paid sick time and can take additional unpaid time off as
-needed in communication with their supervisor.
-
-If a student will miss their shift for any reason, they should post a message in the team slack channel saying that they won't be in. This ensures the team knows not to expect them in meetings, etc, even if their supervisor is also out. The student should follow up individually with their supervisor as to whether they will be using sick time or unpaid time.
-
-## Hiring and Onboarding
-
-Relevant documentation can be found in the [Student hiring Drive folder](https://drive.google.com/drive/u/2/folders/1MTfYgMHMb4FZpUQDqsLWasTqm6QMrdoe).
+Student Software Developers are paid biweekly. Timesheet and pay schedules are available on the [Payroll Cycles website](https://finance.princeton.edu/payroll-labor-accounting/payroll/payroll-basics/monthly-and-biweekly-payroll-cycles)
 
 ## Current and Former DLS Student Software Developers
 


### PR DESCRIPTION
Also reorganize it a bit and add a general team onboarding page.
Reduce duplication of policies spelled out in other places

closes #102
