### PR TITLE
Add a link to the learning friendly board

### DIFF
--- a/development_practice.md
+++ b/development_practice.md
@@ -8,6 +8,9 @@ Each week we either work from the [Work Cycle
 Board](https://app.zenhub.com/workspaces/dls-work-cycle-613924a1df719e0013b678b0/board?repos=98223070)
 or the [Maintenance & Research
 board](https://app.zenhub.com/workspaces/dls-maintenance--research-6139264d4f68940016d4b7cf/board?repos=26446857,98223070,49439415,157741631,251438007).
+
+We also have a [Learning-friendly Board](https://app.zenhub.com/workspaces/dls-learning-friendly-62e046ab829aafbe2d6520b2/board) for members of our team who are focused on training and not working on work cycle issues.
+
 The `ready` column of a given board has issues ordered roughly by priority.
 Always assign yourself to an issue before to starting to work on it, and move it
 to the `in progress` column.


### PR DESCRIPTION
I think this makes more sense with the other boards than with the
student developers documentation

closes #88
