### PR TITLE
Move work cycles near development practice in sidebar

### DIFF
--- a/development_practice.md
+++ b/development_practice.md
@@ -1,8 +1,6 @@
 # Development Practice
 
-## Routine / Project work
-
-### Selecting an issue
+## Selecting an issue
 
 Each week we either work from the [Work Cycle
 Board](https://app.zenhub.com/workspaces/dls-work-cycle-613924a1df719e0013b678b0/board?repos=98223070)
@@ -15,7 +13,7 @@ The `ready` column of a given board has issues ordered roughly by priority.
 Always assign yourself to an issue before to starting to work on it, and move it
 to the `in progress` column.
 
-### Pairing
+## Pairing
 
 Our team considers ourselves "pairing-friendly." Several of us very much like to
 pair, and we all do pair at least sometimes. We've tried various ways of
@@ -42,7 +40,7 @@ Checklist for every time you pair:
 - [ ] Use Co-authored-by lines in the commit message (This [.gitmessage](https://github.com/pulibrary/pul-the-hard-way/blob/main/gitmessage.md) file might be handy)
 - [ ] Check in afterwards about how it went. 
 
-### Submitting code
+## Submitting code
 
 * Ensure code is arranged in logical, unitary commits unless you want it squash-merged.
 * Ensure any new or modified code has test coverage. Many of us practice test-driven development, but at the least a test should be confirmed to be failing before the code change is applied.
@@ -56,7 +54,7 @@ Checklist for every time you pair:
 without waiting for another reviewer.
 * Ensure the issue is closed if no further work is required.
 
-### Reviewing code
+## Reviewing code
 
 * Review other pull requests over the course of the day.
 * We generally follow the [Samvera Code Review](https://samvera.github.io/review.html) guidelines

--- a/index.md
+++ b/index.md
@@ -24,26 +24,6 @@ our work within the broader vision and move it forward.
 
 DLS will prioritize development work and organization processes in such a way as to have the most impact towards this vision, and we encourage our partners and stakeholders to imagine ways for us to get there together.
 
-## Documentation for general use
-
-1. [Applications](/applications.md) - Information about applications in the DLS portfolio
-1. [Issues](/issues.md) - Writing and specifying tickets
-1. [Product Owners](/product_owners.md)
-1. [Technical Liaisons](/technical_liaisons.md)
-1. [Work Cycles](/work_cycles.md)
-
-## Documentation most useful to members of our team
-
-1. [Administrative Resources](/admin_resources.md)
-1. [Development Practice](/development_practice.md)
-1. [Development Tooling](/tooling.md)
-1. [Improving User Experience](/ux_research.md)
-1. [Inclusive Language](/inclusive_language.md)
-1. [Onboarding](/onboarding.md) to the DLS team
-1. [Runner](/runner.md) - The nature and duties of the rotating "runner" role
-1. [Student Software Developers](student_software_developers.md)
-1. [Vacation](/vacation.md)
-
 ## Feedback
 We'd love to hear your feedback and questions about the contents of this handbook! You can contact us in the following ways:
 

--- a/work_cycles.md
+++ b/work_cycles.md
@@ -1,3 +1,7 @@
+---
+layout: default
+title: Development Work Cycles
+---
 # Work Cycles
 
 ## Development Rhythm


### PR DESCRIPTION
I think this makes the sidebar flow actually not too bad if you just
read it top to bottom. I removed the lists of links from the front page,
since all the pages honestly are probably useful to anyone.

Also improves the page TOC for the development practice page

![Screenshot 2024-03-21 at 2 53 16 PM](https://github.com/pulibrary/dls-handbook/assets/845363/4fecece0-0228-4c40-8540-ec72b1457c89)

closes #107 